### PR TITLE
Create privacy policy GitHub Pages site for Brieftaube

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# brieftaube
+# Brieftaube Datenschutzseite
+
+Diese Repository enthält die statische GitHub-Pages-Website der Brieftaube-App
+mit einer gestalteten Datenschutzerklärung. Öffnen Sie `index.html`, um die
+Seite lokal im Browser zu betrachten.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,389 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Brieftaube – Datenschutzerklärung</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="container">
+        <nav class="top-bar" aria-label="Hauptnavigation">
+          <span class="brand">Brieftaube</span>
+          <a class="button" href="#kontakt">Kontakt</a>
+        </nav>
+        <div class="hero-content">
+          <h1>Datenschutzerklärung</h1>
+          <p>
+            Unsere App Brieftaube schützt die Privatsphäre Ihrer Organisation und
+            Ihrer Familien. Auf dieser Seite finden Sie alle wichtigen
+            Informationen zur Verarbeitung personenbezogener Daten.
+          </p>
+        </div>
+      </div>
+      <div class="gradient"></div>
+    </header>
+
+    <main>
+      <section class="notice">
+        <div class="container">
+          <h2>Wichtiger Hinweis</h2>
+          <p>
+            Dieses Muster ersetzt keine Rechtsberatung. Bitte ergänzen Sie Ihre
+            verantwortliche Stelle, Kontaktdaten, zuständige Aufsichtsbehörde,
+            konkrete Firebase-Regionen sowie etwaige Speicherfristen.
+          </p>
+        </div>
+      </section>
+
+      <section class="section" id="verantwortlicher">
+        <div class="container">
+          <h2>Verantwortlicher</h2>
+          <div class="card-grid">
+            <article class="card">
+              <h3>Organisation</h3>
+              <p>
+                [Name/Organisation des Verantwortlichen]<br />
+                [Postanschrift]<br />
+                [E-Mail-Adresse und ggf. Telefonnummer]
+              </p>
+            </article>
+            <article class="card">
+              <h3>Datenschutzbeauftragter</h3>
+              <p>
+                [Name/Kontakt] oder „nicht benannt“<br />
+                <span class="hint"
+                  >Bitte tragen Sie hier Ihre konkreten Ansprechpartner ein.</span
+                >
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="datenkategorien">
+        <div class="container">
+          <h2>Verarbeitete Datenkategorien</h2>
+          <div class="card-grid two-column">
+            <article class="card">
+              <h3>Kontodaten</h3>
+              <p>
+                Benutzername/Anzeigename, E-Mail, Profilbild, Geburtstag,
+                kurze Bio.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Kommunikationsdaten</h3>
+              <p>
+                Chats (Text, Bilder, Videos, Dateien, Umfragen),
+                Lesebestätigungen, Reaktionen.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Organisationsdaten</h3>
+              <p>
+                Mitgliedschaften, Rollen (Admin/Member), Gruppen/Ordner,
+                Aufgaben/To-Dos, Systemnachrichten.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Kalenderdaten</h3>
+              <p>
+                Titel, Beschreibung, Ort, Zeiten, Wiederholungen, Erinnerungen,
+                Teilnehmende.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Kinder- &amp; Gesundheitsdaten</h3>
+              <p>
+                Vor-/Nachname, Geburtsdatum, Geschlecht, Adresse, Allergien,
+                gesundheitliche Hinweise, Ernährung, Notfallkontakte (Name,
+                Beziehung, Telefon, E-Mail).
+              </p>
+              <p class="hint">
+                Quelle: Eltern/Erziehungsberechtigte über das öffentliche
+                Formular.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Geräte- &amp; Nutzungsdaten</h3>
+              <p>
+                Push-Token (FCM), Sprache/Region, technische Logs, ggf.
+                Betriebssystem-Berechtigungen (Kamera, Medien/Dateien,
+                Standort).
+              </p>
+            </article>
+            <article class="card">
+              <h3>Standortdaten</h3>
+              <p>Nur bei aktiver Freigabe, z.&nbsp;B. „Standort teilen“ im Chat.</p>
+            </article>
+            <article class="card">
+              <h3>Lokale Caches</h3>
+              <p>
+                Inhalte werden verschlüsselt lokal gespeichert (Hive,
+                Firestore-Offlinecache) für die Offline-Nutzung.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="zwecke">
+        <div class="container">
+          <h2>Zwecke der Verarbeitung</h2>
+          <ul class="styled-list">
+            <li>Bereitstellung aller App-Funktionen wie Chats, Dateien, To-Dos.</li>
+            <li>Push-Benachrichtigungen zu Nachrichten, Aufgaben und Terminen.</li>
+            <li>
+              Verwaltung von Kinderdaten für Gruppen und Veranstaltungen
+              inklusive Notfallinformationen.
+            </li>
+            <li>
+              Sicherheit, Fehlersuche, Missbrauchsvermeidung und
+              Leistungsoptimierung.
+            </li>
+            <li>Erfüllung gesetzlicher Pflichten (z. B. Aufbewahrung, Auskunft).</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="section" id="rechtsgrundlagen">
+        <div class="container">
+          <h2>Rechtsgrundlagen (DSGVO)</h2>
+          <div class="card-grid">
+            <article class="card">
+              <h3>Vertragserfüllung (Art. 6 Abs. 1 lit. b)</h3>
+              <p>
+                Verarbeitung von Konten, Chats, Dateien, Terminen und Aufgaben
+                zur Bereitstellung der App.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Berechtigte Interessen (Art. 6 Abs. 1 lit. f)</h3>
+              <p>
+                Sicherheit, Betrugsprävention, technische Logs und Offline-Cache
+                zur Stabilität der App.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Einwilligung (Art. 6 Abs. 1 lit. a)</h3>
+              <p>
+                Push-Benachrichtigungen (insbesondere iOS), Standortfreigaben,
+                Profilbilder und optionale Angaben. Widerruf jederzeit möglich.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Besondere Kategorien (Art. 9 Abs. 2 lit. a)</h3>
+              <p>
+                Gesundheits- und Kinderdaten nur mit ausdrücklicher Einwilligung
+                der Eltern/Erziehungsberechtigten, ggf. zusätzlich Art. 6 Abs. 1
+                lit. b/f.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="empfaenger">
+        <div class="container">
+          <h2>Empfänger &amp; Drittlandtransfer</h2>
+          <div class="card-grid two-column">
+            <article class="card">
+              <h3>Auftragsverarbeiter</h3>
+              <p>
+                Google Ireland Ltd. (Firebase Authentication, Cloud Firestore,
+                Cloud Storage, Cloud Messaging). Verarbeitung gemäß Google Data
+                Processing Terms inkl. Standardvertragsklauseln; Transfer in die
+                USA möglich.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Interne Empfänger</h3>
+              <p>
+                Organisations-Admins und -Mitglieder gemäß den jeweiligen
+                Berechtigungen und Sichtbarkeiten.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Externe Tools</h3>
+              <p>
+                Betriebssystem-Benachrichtigungsdienste und optionale
+                Karten-Apps. Keine automatische Standortübermittlung.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Keine Weitergabe zu Werbezwecken</h3>
+              <p>
+                Es werden keine Daten an Werbenetzwerke oder externe Analytics
+                Tools übermittelt.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="berechtigungen">
+        <div class="container">
+          <h2>Berechtigungen &amp; Gerätezugriffe</h2>
+          <ul class="styled-list">
+            <li>Kamera/Medien/Dateien: freiwilliges Hochladen von Inhalten.</li>
+            <li>Benachrichtigungen: opt-in für Push-Mitteilungen.</li>
+            <li>Standort: nur bei aktiver Freigabe innerhalb von Chats.</li>
+            <li>Internet: Synchronisation, Offline-Nutzung via lokale Caches.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="section" id="speicherorte">
+        <div class="container">
+          <h2>Speicherorte &amp; Speicherdauer</h2>
+          <ul class="styled-list">
+            <li>
+              Firebase-Server (Region gemäß Projektkonfiguration, z. B.
+              „europe-west“). Bitte konkretisieren.
+            </li>
+            <li>
+              Verschlüsselter Gerätespeicher/Appspeicher (Hive,
+              Firestore-Offlinecache).
+            </li>
+            <li>
+              Speicherung bis zur Kontolöschung, Widerruf der Einwilligung oder
+              Wegfall des Zwecks; gesetzliche Aufbewahrungsfristen bleiben
+              unberührt.
+            </li>
+            <li>Push-Token bis Abmeldung oder Token-Refresh.</li>
+            <li>
+              Chat- und Dateiinhalte bis zur Löschung durch Nutzer/Org oder
+              Kontoauflösung.
+            </li>
+            <li>
+              Kinder- und Gesundheitsdaten bis Ende des Zwecks bzw. Widerruf mit
+              restriktiver Zugriffssteuerung.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="section" id="transparenz">
+        <div class="container">
+          <h2>Weitergabe &amp; Transparenz innerhalb der Organisation</h2>
+          <p>
+            Die Sichtbarkeit von Daten richtet sich nach der Organisation, den
+            Gruppen und der Zugehörigkeit. Kinder- und Gesundheitsdaten sind nur
+            für berechtigte Organisatoren bzw. Betreuer einsehbar und werden
+            ausschließlich zweckgebunden verwendet.
+          </p>
+        </div>
+      </section>
+
+      <section class="section" id="rechte">
+        <div class="container">
+          <h2>Ihre Rechte</h2>
+          <div class="card-grid two-column">
+            <article class="card">
+              <h3>Standardrechte</h3>
+              <p>
+                Auskunft, Berichtigung, Löschung, Einschränkung und
+                Datenübertragbarkeit (Art. 15–20 DSGVO).
+              </p>
+            </article>
+            <article class="card">
+              <h3>Widerspruch &amp; Widerruf</h3>
+              <p>
+                Widerspruch gegen Verarbeitungen auf Basis berechtigter
+                Interessen (Art. 21 DSGVO) sowie Widerruf von Einwilligungen (Art.
+                7 Abs. 3 DSGVO), etwa für Push oder Standort.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Beschwerderecht</h3>
+              <p>
+                Beschwerde bei einer Datenschutzaufsichtsbehörde Ihrer Wahl.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Kontakt</h3>
+              <p>
+                Zur Ausübung Ihrer Rechte wenden Sie sich bitte an den
+                Verantwortlichen unter den oben genannten Kontaktdaten.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="bereitstellung">
+        <div class="container">
+          <h2>Verpflichtung zur Bereitstellung</h2>
+          <p>
+            Für die Registrierung sind Basisdaten (E-Mail, Passwort, Nutzername)
+            erforderlich. Ohne diese Angaben ist eine Nutzung der App nicht
+            möglich. Kinder- und Gesundheitsdaten werden nur erhoben, wenn Sie
+            das öffentliche Formular absenden; ohne diese Informationen können
+            bestimmte Organisationsteilnahmen (z. B. Camps) ggf. nicht
+            sichergestellt werden.
+          </p>
+        </div>
+      </section>
+
+      <section class="section" id="sicherheit">
+        <div class="container">
+          <h2>Sicherheit</h2>
+          <ul class="styled-list">
+            <li>Transportverschlüsselung (TLS) und serverseitige Verschlüsselung.</li>
+            <li>Zugriffsschutz über Rollen und Berechtigungen (Firestore-Regeln).</li>
+            <li>
+              Lokale Datenablage ausschließlich für App-Zwecke. Bitte schützen Sie
+              Ihre Geräte (z. B. durch Bildschirmsperre).
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="section" id="cookies">
+        <div class="container">
+          <h2>Cookies &amp; Tracking</h2>
+          <p>
+            Es findet kein Tracking zu Werbezwecken statt. Die Webversion nutzt
+            ausschließlich technisch notwendige Speichermechanismen wie Service
+            Worker, Sitzungs- und Browsercache.
+          </p>
+        </div>
+      </section>
+
+      <section class="section" id="kinder">
+        <div class="container">
+          <h2>Kinder und Einwilligung</h2>
+          <p>
+            Für Kinderdaten ist die vorherige Zustimmung der Eltern oder
+            Erziehungsberechtigten erforderlich. Diese wird über das öffentliche
+            Formular eingeholt („Mit dem Absenden … stimmen Sie zu …“). Ein
+            Widerruf ist jederzeit möglich. Bitte benennen Sie eine interne
+            Anlaufstelle für Eltern und dokumentieren Sie die erteilten
+            Einwilligungen.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer" id="kontakt">
+      <div class="container">
+        <p>&copy; <span id="year"></span> Brieftaube. Alle Rechte vorbehalten.</p>
+        <p class="hint">
+          Aktualisiert: <time datetime="2024-01-01">Bitte Datum eintragen</time>
+        </p>
+      </div>
+    </footer>
+
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: light dark;
+  --background: #f5f6fb;
+  --foreground: #0b1b2b;
+  --accent: #3b82f6;
+  --accent-strong: #1d4ed8;
+  --muted: #64748b;
+  --card-bg: rgba(255, 255, 255, 0.82);
+  --card-border: rgba(15, 23, 42, 0.08);
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.15);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--background);
+  color: var(--foreground);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin-inline: auto;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(135deg, #0f172a 0%, #1e40af 40%, #1d4ed8 100%);
+  color: white;
+  padding: 3.5rem 0 5rem;
+  margin-bottom: 3rem;
+  border-radius: 0 0 48px 48px;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 3rem;
+  font-weight: 600;
+}
+
+.brand {
+  font-size: 1.35rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.button {
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-weight: 500;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.button:hover {
+  background: rgba(255, 255, 255, 0.3);
+  border-color: rgba(255, 255, 255, 0.6);
+}
+
+.hero-content {
+  max-width: 38rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  margin-bottom: 1rem;
+  font-weight: 700;
+}
+
+.hero p {
+  font-size: 1.1rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.gradient {
+  position: absolute;
+  inset: auto -30% -45% -30%;
+  height: 55%;
+  background: radial-gradient(circle at center, rgba(59, 130, 246, 0.65), transparent 70%);
+  filter: blur(60px);
+  pointer-events: none;
+}
+
+.notice {
+  background: rgba(59, 130, 246, 0.08);
+  border-left: 4px solid var(--accent);
+  padding: 2rem 0;
+  margin: 0 0 3rem;
+}
+
+.notice h2 {
+  margin-bottom: 0.75rem;
+}
+
+.section {
+  margin: 0 0 3.5rem;
+}
+
+.section h2 {
+  font-size: clamp(1.75rem, 3vw, 2.4rem);
+  margin-bottom: 1.5rem;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  backdrop-filter: blur(12px);
+  box-shadow: var(--shadow);
+}
+
+.card h3 {
+  font-size: 1.2rem;
+  margin-bottom: 0.75rem;
+  color: var(--accent-strong);
+}
+
+.card p + p {
+  margin-top: 0.75rem;
+}
+
+.hint {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.two-column {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.styled-list {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.styled-list li {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.footer {
+  background: #0f172a;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 3rem 0;
+  text-align: center;
+  border-radius: 48px 48px 0 0;
+  margin-top: 5rem;
+}
+
+.footer .hint {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 2.5rem 0 3.5rem;
+  }
+
+  .top-bar {
+    margin-bottom: 2rem;
+  }
+
+  .hero p {
+    font-size: 1rem;
+  }
+
+  .styled-list {
+    gap: 0.75rem;
+  }
+
+  .styled-list li {
+    padding: 1rem 1.2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a privacy policy landing page for the Brieftaube app with a structured layout and clear placeholders for organisation-specific details
- introduce a polished visual design with typography, card layouts, and responsive styling for GitHub Pages
- document the repository purpose in the README for easier onboarding

## Testing
- Manual verification in a local browser

------
https://chatgpt.com/codex/tasks/task_e_68e2d04d4374832fb1382adb788771a8